### PR TITLE
add setting for videotype/quality

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -16,6 +16,8 @@ import urllib
 import xbmcaddon
 import json
 from BeautifulSoup import BeautifulSoup
+from xbmcswift2 import Plugin
+
 
 def fetch_video_data(video_id):
         url = "http://www.nytimes.com/svc/video/api/v2/video/" + str(video_id)
@@ -29,8 +31,8 @@ def fetch_video_data(video_id):
 	videos = []
 	for x in range(0,count):
         	videos.append((data["renditions"][x]["fileSize"],data["renditions"][x]["type"],data["renditions"][x]["url"]))
-	video_list = sorted(videos, reverse=True)
-	video_link = video_list[0][2]
+	video_link = videos[videotype][2]
+        #print "video_link: " + video_link
 	try:
                 thumbnail = "http://www.nytimes.com/" + data["images"][5]["url"]
         except:
@@ -55,8 +57,8 @@ def getContent(base_url, sections):
                 for x in holder:
                         sub_name = "".join(part[0])
                         try:
-                                        video_id = x["data-id"]
-                                        content.append((video_id))
+                                video_id = x["data-id"]
+                                content.append((video_id))
                         except KeyError:
                                 print "No Data"
                                 pass
@@ -76,6 +78,10 @@ global sections
 global content
 sections = []
 content = []
+
+plugin = Plugin()
+videotype = plugin.get_setting('videotype', int)
+
 
 def build_url(query):
     return base_url + '?' + urllib.urlencode(query)

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nytimes" name="New York Times Video" version="1.0.1" provider-name="netw1z">
+<addon id="plugin.video.nytimes" name="New York Times Video" version="1.0.2" provider-name="netw1z">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
+	<import addon="script.module.xbmcswift2" version="2.4.0"/>
     <import addon="script.module.beautifulsoup" version="3.2.1"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+	<setting id="videotype" type="enum" label="54351" values="video_240p_mp4|video_360p_mp4|video_480p_mp4|480p_webm|video_1080p_mp4|video_720p_mp4|syndication|hls" default="6"/>
+</settings>
+


### PR DESCRIPTION
The current HD quality setting makes the NYTimes plugin unusable on a slow host (e.g. raspberry) with a bad Wifi connection and an even worse internet connection.
Thus I added a setting to choose the quality.

	modified:   addon.py
	modified:   addon.xml
	new file:   resources/settings.xml